### PR TITLE
Subtree expansion works again in Java 11/Java 17

### DIFF
--- a/src/main/java/de/javagl/treetable/JTreeTable.java
+++ b/src/main/java/de/javagl/treetable/JTreeTable.java
@@ -327,7 +327,7 @@ public class JTreeTable extends JTable
                             me.getModifiers(), me.getX()
                             - getCellRect(0, counter, true).x,
                             me.getY(), me.getClickCount(),
-                            me.isPopupTrigger());
+                            me.isPopupTrigger(), me.getButton());
                     tree.dispatchEvent(newME);
                     break;
                 }


### PR DESCRIPTION
JTreeTable.TreeTableCellEditor creates a MouseEvent for the underlying JTree. It missed the "button" parameter added in some Java Swing version. Java 8's JTree could cope with this, Java 11's does not expand (and collapse) subtrees any more without.
The changed code works with Java 8, Java 11, and Java 17.